### PR TITLE
Restore PHP 5 compatibility

### DIFF
--- a/plugins-list.php
+++ b/plugins-list.php
@@ -172,7 +172,10 @@ function get_plugins_list( $format, $show_inactive, $show_active, $cache, $nofol
 
 	if ( 'true' === $by_author ) {
 		usort( $plugins, function( $a, $b ) {
-			return strtoupper( $a['Author'] ) <=> strtoupper( $b['Author'] );
+			if ( strtoupper( $a['Author'] ) == strtoupper( $b['Author'] ) ) {
+				return 0;
+			}
+			return ( strtoupper( $a['Author'] ) < strtoupper( $b['Author'] ) ) ? -1 : 1;
 		});
 	}
 


### PR DESCRIPTION
The only PHP 5-incompatible operation in the whole plugin was the `<=>` operator used in sorting by author. This slightly more verbose sorting function does the same thing, and is backward-compatible.