### PR TITLE
Fix author sort

### DIFF
--- a/plugins-list.php
+++ b/plugins-list.php
@@ -171,7 +171,7 @@ function get_plugins_list( $format, $show_inactive, $show_active, $cache, $nofol
 	// Sort the plugin array if required in author sequence
 
 	if ( 'true' === $by_author ) {
-		usort( $plugins, function( $a, $b ) {
+		uasort( $plugins, function( $a, $b ) {
 			return strtoupper( $a['Author'] ) <=> strtoupper( $b['Author'] );
 		});
 	}


### PR DESCRIPTION
`usort()` replaces the array keys, so sorting `$plugins` with it made the key (`$plugin_file`) into just an integer. Checking whether an integer is an active plugin obviously fails. When I tested enabling author sorting, the list only contained the first entry, for some reason (it should have been empty).

Using `uasort()` instead preserves the array keys and lets the checks for whether each plugin is active work properly.

This will probably merge-conflict with #17, but I'm happy to rebase either PR for you if needed.

(Edit: Removed extra commits… not sure how those got in, but they're gone now.)